### PR TITLE
Add clear option

### DIFF
--- a/bin/openapi_builder
+++ b/bin/openapi_builder
@@ -12,6 +12,10 @@ OptionParser.new { |opts|
   opts.on("--filter=PATHS", Array, "Filter documentation by paths: 'pets,clients/me'") do |paths|
     options[:paths] = paths
   end
+
+  opts.on("--clear", "Remove unused models and tags from documentation") do |clear|
+    options[:clear] = true
+  end
 }.parse!
 
 builder = ->() { OpenapiBuilder.call(ARGV[0], **options) }

--- a/lib/openapi_builder/core.rb
+++ b/lib/openapi_builder/core.rb
@@ -15,10 +15,11 @@ module OpenapiBuilder
 
     private
 
-    def initialize(path_to_spec, paths: [])
+    def initialize(path_to_spec, paths: [], clear: false)
       @dirname = File.dirname(path_to_spec)
       @data = load_file(path_to_spec)
       @paths = paths
+      @clear = clear
       load_paths
       load_components
     end


### PR DESCRIPTION
With `--clear` option builder clears result documentation from unused tags and models.